### PR TITLE
Minor improvements to check_versions

### DIFF
--- a/check_versions/__init__.py
+++ b/check_versions/__init__.py
@@ -29,7 +29,7 @@ def is_freebsd():
     return sys.platform == 'freebsd'
 
 
-@memoize
+@memoize()
 def os_release():
     """Return a dict containing a normalized version of /etc/os-release."""
     lines = Path('/etc/os-release').read_text().strip().split('\n')

--- a/check_versions/__init__.py
+++ b/check_versions/__init__.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 import shlex
 from subprocess import check_output
-# import sys
+import sys
 
 
 def run(cmd):
@@ -19,18 +19,14 @@ def run(cmd):
     return output
 
 
-# We memoize() is_linux() to avoid running the same command repeatedly.
-@memoize()
 def is_linux():
     """Return True if the system is running Linux; False otherwise."""
-    return run('uname -s') == 'Linux'
+    return sys.platform == 'linux'
 
 
-# We memoize() is_freebsd() to avoid running the same command repeatedly.
-# FIXME: actually memoize() this. (avoiding changing functionality atm.)
 def is_freebsd():
     """Return True if the system is running FreeBSD; False otherwise."""
-    return run('uname -s') == 'FreeBSD'
+    return sys.platform == 'freebsd'
 
 
 def os_release():

--- a/check_versions/__init__.py
+++ b/check_versions/__init__.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 import shlex
 from subprocess import check_output
-import platform
+import sys
 
 
 def run(cmd):
@@ -21,12 +21,12 @@ def run(cmd):
 
 def is_linux():
     """Return True if the system is running Linux; False otherwise."""
-    return platform.system() == 'Linux'
+    return sys.platform.startswith('linux')
 
 
 def is_freebsd():
     """Return True if the system is running FreeBSD; False otherwise."""
-    return platform.system() == 'FreeBSD'
+    return sys.platform.startswith('freebsd')
 
 
 @memoize()

--- a/check_versions/__init__.py
+++ b/check_versions/__init__.py
@@ -29,6 +29,7 @@ def is_freebsd():
     return sys.platform == 'freebsd'
 
 
+@memoize
 def os_release():
     """Return a dict containing a normalized version of /etc/os-release."""
     lines = Path('/etc/os-release').read_text().strip().split('\n')

--- a/check_versions/__init__.py
+++ b/check_versions/__init__.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 import shlex
 from subprocess import check_output
-import sys
+import platform
 
 
 def run(cmd):
@@ -21,12 +21,12 @@ def run(cmd):
 
 def is_linux():
     """Return True if the system is running Linux; False otherwise."""
-    return sys.platform == 'linux'
+    return platform.system() == 'Linux'
 
 
 def is_freebsd():
     """Return True if the system is running FreeBSD; False otherwise."""
-    return sys.platform == 'freebsd'
+    return platform.system() == 'FreeBSD'
 
 
 @memoize()


### PR DESCRIPTION
- [x] Avoid shelling out to `uname`.
- [x] Avoid reading and parsing `/etc/os-release` multiple times