### PR TITLE
More cleanups

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,17 +35,10 @@ check_versions_task:
   json_artifacts:
     path: "source/*.json"
 
-task:
-  name: site gen success
-  container:
-    image: busybox
+render_task:
   depends_on:
     - lint
     - check_versions
-
-render_task:
-  depends_on:
-    - site gen success
   container:
     image: python:3-slim
   install_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,10 +1,10 @@
 lint_task:
+  environment:
+    CIRRUS_SHELL: direct
   container:
-    image: python:3-slim
-  install_script:
-    - pip3 install ruff
+    image: ghcr.io/astral-sh/ruff
   script:
-    - ruff check
+    - /ruff check
 
 check_versions_task:
   matrix:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -67,52 +67,41 @@ task:
     - debian_and_ubuntu
     - freebsd
 
-# Generate the site and publish it, for main branch.
-publish_task:
-  only_if: $BRANCH == 'main'
+render_task:
   depends_on:
     - site gen success
+  container:
+    image: python:3-slim
+  install_script:
+    - pip install lxml
+  script:
+    - python3 -m generate_site $CIRRUS_BUILD_ID
+    - stat _site/index.html
+    - tar -cf site.tar _site/
+  site_artifacts:
+    path: "site.tar"
+
+# Publish updates merged to the main branch
+publish_task:
+  skip: $BRANCH != 'main'
+  depends_on:
+    - render
   container:
     image: node:20-bookworm
   env:
-    NETLIFY_AUTH_TOKEN: ENCRYPTED[ec6da05d365917ed543e307555cbd9c618bbd41db7dee828daf7b01825adef48f547db89ead63b99418fe07a9d41b43a]
-    NETLIFY_SITE_ID: ENCRYPTED[a408add4551cd62fe8a5a912569fda66b5e991dd1097a8eaf0a6479179a07a6ec3e5d9e0c67d16f61c67a6721a728a91]
+    TOKEN:
+      ENCRYPTED[ec6da05d365917ed543e307555cbd9c618bbd41db7dee828daf7b01825adef48f547db89ead63b99418fe07a9d41b43a]
+    SITE_ID:
+      ENCRYPTED[a408add4551cd62fe8a5a912569fda66b5e991dd1097a8eaf0a6479179a07a6ec3e5d9e0c67d16f61c67a6721a728a91]
   install_script:
-    - apt-get -y update
-    - apt-get -y install python3 python3-lxml
     # https://github.com/netlify/cli/issues/1870
     - npm install --unsafe-perm=true -g netlify-cli
   script:
-    - python3 -m generate_site $CIRRUS_BUILD_ID
-    - stat _site/index.html
-    - netlify deploy --auth $NETLIFY_AUTH_TOKEN --site $NETLIFY_SITE_ID --dir=_site --prod
-
-# Generates the site but don't publish it, for non-main branches.
-fake_publish_task:
-  only_if: $BRANCH != 'main'
-  depends_on:
-    - site gen success
-  container:
-    image: node:20-bookworm
-  install_script:
-    - apt-get -y update
-    - apt-get -y install python3 python3-lxml
-    # https://github.com/netlify/cli/issues/1870
-    - npm install --unsafe-perm=true -g netlify-cli
-  script:
-    - python3 -m generate_site $CIRRUS_BUILD_ID
-    - stat _site/index.html
+    - wget "https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}/render/site/site.tar" -O - | tar -vx
+    - netlify deploy --auth $TOKEN --site $SITE_ID --dir=_site --prod
 
 task:
-  only_if: $BRANCH == 'main'
   name: CI success
   container: {image: busybox}
   depends_on:
-    - publish
-
-task:
-  only_if: $BRANCH != 'main'
-  name: CI success
-  container: {image: busybox}
-  depends_on:
-    - fake_publish
+    - publish  # marked as successful on skip

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,51 +6,31 @@ lint_task:
   script:
     - ruff check
 
-archlinux_and_manjaro_task:
-  container:
-    matrix:
-      - image: archlinux:latest
-      - image: manjarolinux/base:latest
-  install_script: pacman -Sy --noconfirm python3
-  script: python3 ./check_versions.py
-  json_artifacts:
-    path: "source/*.json"
+check_versions_task:
+  matrix:
+    - freebsd_instance: {image_family: freebsd-14-0}
+    - container: {image: fedora:latest}
+    - container:
+        matrix:
+          - image: archlinux:latest
+          - image: manjarolinux/base:latest
+      install_script: pacman -Sy --noconfirm python3
 
-fedora_task:
-  container:
-    matrix:
-      - image: fedora:latest
-  script: python3 ./check_versions.py
-  json_artifacts:
-    path: "source/*.json"
+    - container:
+        matrix:
+          - image: debian:oldstable-slim
+          - image: debian:stable-slim
+          - image: ubuntu:latest
+      install_script:
+        - apt-get -y update
+        - apt-get -y install python3
 
-opensuse_task:
-  container:
-    matrix:
-      - image: opensuse/leap:latest
-      - image: opensuse/tumbleweed:latest
-  install_script: zypper install --no-confirm python3
-  script: python3 ./check_versions.py
-  json_artifacts:
-    path: "source/*.json"
+    - container:
+        matrix:
+          - image: opensuse/leap:latest
+          - image: opensuse/tumbleweed:latest
+      install_script: zypper install --no-confirm python3
 
-debian_and_ubuntu_task:
-  container:
-    matrix:
-      - image: debian:oldstable-slim
-      - image: debian:stable-slim
-      - image: ubuntu:latest # Most recent LTS - see https://hub.docker.com/_/ubuntu
-  install_script:
-    - apt-get -y update
-    - apt-get -y install python3
-  script: python3 ./check_versions.py
-  json_artifacts:
-    path: "source/*.json"
-
-freebsd_task:
-  freebsd_instance:
-    matrix:
-      - image_family: freebsd-14-0
   script: python3 ./check_versions.py
   json_artifacts:
     path: "source/*.json"
@@ -61,11 +41,7 @@ task:
     image: busybox
   depends_on:
     - lint
-    - archlinux_and_manjaro
-    - fedora
-    - opensuse
-    - debian_and_ubuntu
-    - freebsd
+    - check_versions
 
 render_task:
   depends_on:

--- a/check_versions.py
+++ b/check_versions.py
@@ -204,13 +204,17 @@ def discover():
     if sys.platform.startswith('freebsd'):
         os_name = 'FreeBSD'
         os_desc = run('uname -sr')
-    else: # Assume everything else is Linux.
+
+    elif sys.platform == "linux":
         # Treat /etc/os-release as a key/value pair of strings,
         # with optional quotes on the value side.
         os_release = {k: v[1:-1] if v[0] == '"' else v for (k, v) in [line.split("=") for line in Path("/etc/os-release").read_text().splitlines() if not line.startswith("#")]}
         os_name = os_release['NAME'].replace(' GNU/Linux', '')
         os_version = os_release.get('VERSION_ID', '')
         os_desc = '{} {}'.format(os_name, os_version).strip()
+
+    else:
+        raise NotImplementedError(f"Only FreeBSD and Linux are currenctly supported, not '{sys.platform}'")
 
     return DISTROS[os_name](os_name, os_desc)
 

--- a/generate_site/__init__.py
+++ b/generate_site/__init__.py
@@ -29,12 +29,12 @@ def build_index(directory):
     ])
 
 
-def download_data(build_id, os_name):
+def download_data(build_id, task_name = 'check_versions'):
     """Download relevant Cirrus CI artifacts."""
     Path('_data').mkdir(exist_ok=True)
 
     uri_domain = 'https://api.cirrus-ci.com'
-    uri_path = '/v1/artifact/build/{}/{}/json.zip'.format(build_id, os_name)
+    uri_path = '/v1/artifact/build/{}/{}/json.zip'.format(build_id, task_name)
 
     print('Downloading {}{}...'.format(uri_domain, uri_path))
 
@@ -46,20 +46,6 @@ def download_data(build_id, os_name):
         for member in zip_file.infolist():
             print('> Extracting {}'.format(member.filename))
             zip_file.extract(member, path='_data/')
-
-
-def download_all(build_id):
-    """Download Cirrus CI artifacts for all supported operating systems."""
-    os_name_list = [
-        'archlinux_and_manjaro',
-        'fedora',
-        'opensuse',
-        'debian_and_ubuntu',
-        'freebsd',
-    ]
-
-    for os_name in os_name_list:
-        download_data(build_id, os_name)
 
 
 def raw_data():
@@ -155,7 +141,7 @@ def main(argv):
     if build_id.lower() == 'local':
         shutil.copytree('source/', '_data/source/')
     else:
-        download_all(build_id)
+        download_data(build_id)
 
     shutil.copytree('_data/', '_site/data/')
 


### PR DESCRIPTION
- [x] minor simplification & defensive coding in `check_versions.main`
- CI
  - [x] split rendering and publication tasks
        removes duplication and enables downloading the site as rendered in a given build (for PR preview or such)
  - [x] refactor `check_versions` task(s)
  - [x] drop `site gen success` metatask, was only used in a single place
  - [x] use the official container image for `ruff` rather than manually install it (everytime)
